### PR TITLE
fix: repair broken test suite and add full MedInvoiceContract coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,14 +4,14 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "hardhat test"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^4.0.0",
-    "hardhat": "^2.19.2"
+    "hardhat": "^2.28.6"
   },
   "dependencies": {
     "@openzeppelin/contracts": "^5.2.0",

--- a/test/MedInvoiceContract.js
+++ b/test/MedInvoiceContract.js
@@ -1,0 +1,190 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+
+describe("MedInvoiceContract", () => {
+    let pptToken;
+    let invoiceContract;
+    let owner;
+    let subscriber;
+    let nonSubscriber;
+
+    const INITIAL_SUPPLY = 1_000_000n;
+    const SUBSCRIPTION_AMOUNT = ethers.parseEther("10");
+
+    beforeEach(async () => {
+        [owner, subscriber, nonSubscriber] = await ethers.getSigners();
+
+        const PPTToken = await ethers.getContractFactory("PPTToken");
+        pptToken = await PPTToken.deploy(INITIAL_SUPPLY);
+        await pptToken.waitForDeployment();
+
+        const MedInvoice = await ethers.getContractFactory("MedInvoiceContract");
+        invoiceContract = await MedInvoice.deploy(await pptToken.getAddress());
+        await invoiceContract.waitForDeployment();
+
+        // Fund subscriber and contract with tokens so subscribe() works
+        await pptToken.transfer(subscriber.address, SUBSCRIPTION_AMOUNT * 10n);
+        await pptToken.transfer(await invoiceContract.getAddress(), SUBSCRIPTION_AMOUNT * 100n);
+
+        // subscriber approves the contract to pull tokens
+        await pptToken.connect(subscriber).approve(await invoiceContract.getAddress(), SUBSCRIPTION_AMOUNT);
+    });
+
+    describe("Deployment", () => {
+        it("Should set pptToken address correctly", async () => {
+            expect(await invoiceContract.pptToken()).to.equal(await pptToken.getAddress());
+        });
+
+        it("Should set the deployer as owner", async () => {
+            expect(await invoiceContract.owner()).to.equal(owner.address);
+        });
+
+        it("Should have correct SUBSCRIPTION_AMOUNT", async () => {
+            expect(await invoiceContract.SUBSCRIPTION_AMOUNT()).to.equal(SUBSCRIPTION_AMOUNT);
+        });
+    });
+
+    describe("subscribe()", () => {
+        it("Should allow a user to subscribe when they have approved tokens", async () => {
+            await invoiceContract.connect(subscriber).subscribe();
+            expect(await invoiceContract.isSubscribed(subscriber.address)).to.be.true;
+        });
+
+        it("Should emit NewSubscription event", async () => {
+            await expect(invoiceContract.connect(subscriber).subscribe())
+                .to.emit(invoiceContract, "NewSubscription")
+                .withArgs(subscriber.address, (endTime) => endTime > 0n);
+        });
+
+        it("Should set subscription end time ~365 days from now", async () => {
+            const tx = await invoiceContract.connect(subscriber).subscribe();
+            const receipt = await tx.wait();
+            const block = await ethers.provider.getBlock(receipt.blockNumber);
+            const endTime = await invoiceContract.subscriptionEndTimes(subscriber.address);
+            const expected = BigInt(block.timestamp) + BigInt(365 * 24 * 60 * 60);
+            expect(endTime).to.equal(expected);
+        });
+
+        it("Should revert if user is already subscribed", async () => {
+            await invoiceContract.connect(subscriber).subscribe();
+            await pptToken.connect(subscriber).approve(await invoiceContract.getAddress(), SUBSCRIPTION_AMOUNT);
+            await expect(
+                invoiceContract.connect(subscriber).subscribe()
+            ).to.be.revertedWith("Already subscribed");
+        });
+
+        it("Should revert if contract has insufficient token balance to send", async () => {
+            // Deploy a fresh contract with no token balance to confirm transfer failure
+            const MedInvoice = await ethers.getContractFactory("MedInvoiceContract");
+            const emptyContract = await MedInvoice.deploy(await pptToken.getAddress());
+            await emptyContract.waitForDeployment();
+            await expect(
+                emptyContract.connect(nonSubscriber).subscribe()
+            ).to.be.reverted;
+        });
+    });
+
+    describe("saveFile()", () => {
+        it("Should allow token holder to save a file", async () => {
+            await invoiceContract.connect(subscriber).saveFile("ipfs://Qm123");
+            const files = await invoiceContract.connect(subscriber).getFiles();
+            expect(files).to.include("ipfs://Qm123");
+        });
+
+        it("Should emit FileSaved event", async () => {
+            await expect(invoiceContract.connect(subscriber).saveFile("ipfs://Qm123"))
+                .to.emit(invoiceContract, "FileSaved")
+                .withArgs(subscriber.address, "ipfs://Qm123", (ts) => ts > 0n);
+        });
+
+        it("Should revert if file content is empty", async () => {
+            await expect(
+                invoiceContract.connect(subscriber).saveFile("")
+            ).to.be.revertedWith("File content cannot be empty");
+        });
+
+        it("Should revert if caller holds no PPT tokens", async () => {
+            await expect(
+                invoiceContract.connect(nonSubscriber).saveFile("ipfs://Qm123")
+            ).to.be.revertedWith("You need to hold a MediToken to save.");
+        });
+
+        it("Should allow saving multiple files", async () => {
+            await invoiceContract.connect(subscriber).saveFile("ipfs://file1");
+            await invoiceContract.connect(subscriber).saveFile("ipfs://file2");
+            const files = await invoiceContract.connect(subscriber).getFiles();
+            expect(files.length).to.equal(2);
+        });
+    });
+
+    describe("getFiles()", () => {
+        it("Should return files for a token holder", async () => {
+            await invoiceContract.connect(subscriber).saveFile("ipfs://Qm999");
+            const files = await invoiceContract.connect(subscriber).getFiles();
+            expect(files[0]).to.equal("ipfs://Qm999");
+        });
+
+        it("Should revert if caller holds no PPT tokens", async () => {
+            await expect(
+                invoiceContract.connect(nonSubscriber).getFiles()
+            ).to.be.revertedWith("You need to hold a MediToken to view saved files.");
+        });
+
+        it("Should return empty array for a new token holder with no files", async () => {
+            const files = await invoiceContract.connect(subscriber).getFiles();
+            expect(files.length).to.equal(0);
+        });
+    });
+
+    describe("isSubscribed() / getSubscriptionDetails()", () => {
+        it("Should return false for a non-subscriber", async () => {
+            expect(await invoiceContract.isSubscribed(nonSubscriber.address)).to.be.false;
+        });
+
+        it("Should return true after subscribing", async () => {
+            await invoiceContract.connect(subscriber).subscribe();
+            expect(await invoiceContract.isSubscribed(subscriber.address)).to.be.true;
+        });
+
+        it("getSubscriptionDetails should return exists=false for new user", async () => {
+            const [exists] = await invoiceContract.connect(nonSubscriber).getSubscriptionDetails();
+            expect(exists).to.be.false;
+        });
+
+        it("getSubscriptionDetails should return exists=true after subscribe", async () => {
+            await invoiceContract.connect(subscriber).subscribe();
+            const [exists, endTime] = await invoiceContract.connect(subscriber).getSubscriptionDetails();
+            expect(exists).to.be.true;
+            expect(endTime).to.be.gt(0n);
+        });
+    });
+
+    describe("getUserTokens()", () => {
+        it("Should return the caller's token balance", async () => {
+            const balance = await invoiceContract.connect(subscriber).getUserTokens();
+            expect(balance).to.equal(SUBSCRIPTION_AMOUNT * 10n);
+        });
+    });
+
+    describe("withdrawTokens()", () => {
+        it("Should allow owner to withdraw tokens", async () => {
+            const contractBalance = await pptToken.balanceOf(await invoiceContract.getAddress());
+            const ownerBefore = await pptToken.balanceOf(owner.address);
+            await invoiceContract.connect(owner).withdrawTokens(contractBalance);
+            expect(await pptToken.balanceOf(owner.address)).to.equal(ownerBefore + contractBalance);
+        });
+
+        it("Should revert if called by non-owner", async () => {
+            await expect(
+                invoiceContract.connect(subscriber).withdrawTokens(1n)
+            ).to.be.revertedWithCustomError(invoiceContract, "OwnableUnauthorizedAccount");
+        });
+
+        it("Should revert if withdrawing more than contract balance", async () => {
+            const contractBalance = await pptToken.balanceOf(await invoiceContract.getAddress());
+            await expect(
+                invoiceContract.connect(owner).withdrawTokens(contractBalance + 1n)
+            ).to.be.reverted;
+        });
+    });
+});

--- a/test/MedToken.js
+++ b/test/MedToken.js
@@ -1,59 +1,93 @@
 const { expect } = require('chai');
 const { ethers } = require('hardhat');
 
-describe("MediToken Contract", () => {
-    let medToken;
+describe("PPTToken Contract", () => {
+    let pptToken;
     let owner;
     let addr1;
     let addr2;
 
+    const INITIAL_SUPPLY = 1000n;
+    const MINTED_SUPPLY = INITIAL_SUPPLY * 10n ** 18n;
+
     beforeEach(async () => {
-        const MedToken = await ethers.getContractFactory("MediToken");
+        const PPTToken = await ethers.getContractFactory("PPTToken");
         [owner, addr1, addr2] = await ethers.getSigners();
 
-        medToken = await MedToken.deploy(1000); 
-        await medToken.waitForDeployment();
+        pptToken = await PPTToken.deploy(INITIAL_SUPPLY);
+        await pptToken.waitForDeployment();
     });
 
     describe('Deployment', () => {
         it('Should set the correct total supply', async () => {
-            expect(await medToken.totalSupply()).to.equal(1000);
+            expect(await pptToken.totalSupply()).to.equal(MINTED_SUPPLY);
         });
 
         it('Should assign the total supply to the owner', async () => {
-            expect(await medToken.balanceOf(owner.address)).to.equal(1000);
+            expect(await pptToken.balanceOf(owner.address)).to.equal(MINTED_SUPPLY);
+        });
+
+        it('Should set the correct token name and symbol', async () => {
+            expect(await pptToken.name()).to.equal("Park Pro Token");
+            expect(await pptToken.symbol()).to.equal("PPT");
         });
     });
 
     describe('Transactions', () => {
         it('Should transfer tokens between accounts', async () => {
-            await medToken.transfer(addr1.address, 50);
-            expect(await medToken.balanceOf(addr1.address)).to.equal(50);
+            const amount = ethers.parseEther("50");
+            await pptToken.transfer(addr1.address, amount);
+            expect(await pptToken.balanceOf(addr1.address)).to.equal(amount);
 
-            await medToken.connect(addr1).transfer(addr2.address, 50);
-            expect(await medToken.balanceOf(addr2.address)).to.equal(50);
+            await pptToken.connect(addr1).transfer(addr2.address, amount);
+            expect(await pptToken.balanceOf(addr2.address)).to.equal(amount);
         });
 
-        it('Should fail if sender doesn’t have enough tokens', async () => {
-            const initialOwnerBalance = await medToken.balanceOf(owner.address);
+        it('Should fail if sender does not have enough tokens', async () => {
+            const initialOwnerBalance = await pptToken.balanceOf(owner.address);
 
             await expect(
-                medToken.connect(addr1).transfer(owner.address, 1)
+                pptToken.connect(addr1).transfer(owner.address, ethers.parseEther("1"))
             ).to.be.reverted;
 
-            expect(await medToken.balanceOf(owner.address)).to.equal(initialOwnerBalance);
+            expect(await pptToken.balanceOf(owner.address)).to.equal(initialOwnerBalance);
         });
 
         it('Should update balances after transfers', async () => {
-            const initialOwnerBalance = await medToken.balanceOf(owner.address);
+            const amount = ethers.parseEther("100");
+            const initialOwnerBalance = await pptToken.balanceOf(owner.address);
 
-            await medToken.transfer(addr1.address, 100);
+            await pptToken.transfer(addr1.address, amount);
 
-            const finalOwnerBalance = await medToken.balanceOf(owner.address);
-            expect(finalOwnerBalance).to.equal(initialOwnerBalance - BigInt(100));
+            expect(await pptToken.balanceOf(owner.address)).to.equal(initialOwnerBalance - amount);
+            expect(await pptToken.balanceOf(addr1.address)).to.equal(amount);
+        });
 
-            const addr1Balance = await medToken.balanceOf(addr1.address);
-            expect(addr1Balance).to.equal(100);
+        it('Should emit Transfer event on transfer', async () => {
+            const amount = ethers.parseEther("10");
+            await expect(pptToken.transfer(addr1.address, amount))
+                .to.emit(pptToken, "Transfer")
+                .withArgs(owner.address, addr1.address, amount);
+        });
+    });
+
+    describe('Allowances', () => {
+        it('Should approve and transferFrom correctly', async () => {
+            const amount = ethers.parseEther("200");
+            await pptToken.approve(addr1.address, amount);
+            expect(await pptToken.allowance(owner.address, addr1.address)).to.equal(amount);
+
+            await pptToken.connect(addr1).transferFrom(owner.address, addr2.address, amount);
+            expect(await pptToken.balanceOf(addr2.address)).to.equal(amount);
+        });
+
+        it('Should fail transferFrom if allowance is insufficient', async () => {
+            const amount = ethers.parseEther("100");
+            await pptToken.approve(addr1.address, amount);
+
+            await expect(
+                pptToken.connect(addr1).transferFrom(owner.address, addr2.address, amount + 1n)
+            ).to.be.reverted;
         });
     });
 });


### PR DESCRIPTION
## Summary

- **`test/MedToken.js` was broken and could never run.** It referenced a contract called `MediToken` which doesn't exist — the actual contract is `PPTToken`. Supply assertions also used raw `1000` instead of `1000 * 10**18` (which is what the constructor mints). Fixed contract name, updated all supply/balance assertions to use `ethers.parseEther`, added token name/symbol test, Transfer event test, and ERC-20 allowance tests.
- **`test/MedInvoiceContract.js` (new file)** — adds 24 tests for the more complex contract: deployment checks, `subscribe()`, `saveFile()`, `getFiles()`, `isSubscribed()`, `getSubscriptionDetails()`, `getUserTokens()`, and `withdrawTokens()`, including edge cases and revert conditions.
- **`package.json`** test script was `echo "Error: no test specified"`. Changed to `hardhat test`.

**Result: 33/33 tests passing.**

## Test plan

- [ ] `npm install --include=dev && npx hardhat test` → 33 passing, 0 failing

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)