### PR TITLE
fix: subscribe() was sending tokens out instead of collecting them

### DIFF
--- a/contracts/MedInvoiceContract.sol
+++ b/contracts/MedInvoiceContract.sol
@@ -14,6 +14,7 @@ contract MedInvoiceContract is Ownable, ReentrancyGuard {
 
     event FileSaved(address indexed user, string file, uint256 timestamp);
     event NewSubscription(address indexed subscriber, uint256 endTime);
+    event TokensWithdrawn(address indexed owner, uint256 amount);
 
     constructor(address _pptToken) Ownable(msg.sender) {
         pptToken = IERC20(_pptToken);
@@ -55,16 +56,23 @@ contract MedInvoiceContract is Ownable, ReentrancyGuard {
     
     function subscribe() external nonReentrant {
         require(!isSubscribed(msg.sender), "Already subscribed");
-        require(pptToken.transfer(msg.sender, SUBSCRIPTION_AMOUNT), "Token transfer failed");
-        
+        require(
+            pptToken.allowance(msg.sender, address(this)) >= SUBSCRIPTION_AMOUNT,
+            "Insufficient token allowance. Approve the contract first."
+        );
+        require(
+            pptToken.transferFrom(msg.sender, address(this), SUBSCRIPTION_AMOUNT),
+            "Token transfer failed"
+        );
 
         uint256 endTime = block.timestamp + SUBSCRIPTION_PERIOD;
         subscriptionEndTimes[msg.sender] = endTime;
-        
+
         emit NewSubscription(msg.sender, endTime);
     }
 
     function withdrawTokens(uint256 amount) external onlyOwner {
         require(pptToken.transfer(owner(), amount), "Token withdrawal failed");
+        emit TokensWithdrawn(owner(), amount);
     }
 }


### PR DESCRIPTION
## Summary

**Critical logic bug:** `subscribe()` called `pptToken.transfer(msg.sender, SUBSCRIPTION_AMOUNT)` which **sent 10 PPT tokens to the subscriber for free** instead of charging them. Anyone could call `subscribe()` and drain the contract's token balance.

Fixed by changing to `pptToken.transferFrom(msg.sender, address(this), SUBSCRIPTION_AMOUNT)` — the correct pull-payment pattern where the subscriber pays the fee.

Also added:
- An explicit `allowance` check with a human-readable error message so callers understand they need to `approve()` the contract before subscribing.
- A `TokensWithdrawn` event on `withdrawTokens()` for on-chain auditability.

## Before / After

```solidity
// BEFORE (buggy — sends tokens TO subscriber)
require(pptToken.transfer(msg.sender, SUBSCRIPTION_AMOUNT), "Token transfer failed");

// AFTER (correct — pulls tokens FROM subscriber)
require(
    pptToken.allowance(msg.sender, address(this)) >= SUBSCRIPTION_AMOUNT,
    "Insufficient token allowance. Approve the contract first."
);
require(
    pptToken.transferFrom(msg.sender, address(this), SUBSCRIPTION_AMOUNT),
    "Token transfer failed"
);
```

## Test plan

- [ ] Deploy PPTToken + MedInvoiceContract locally
- [ ] Calling `subscribe()` without approving → reverts with allowance error
- [ ] Calling `subscribe()` after `approve(contract, 10e18)` → succeeds, deducts 10 PPT from caller
- [ ] Calling `subscribe()` twice → reverts with "Already subscribed"

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)